### PR TITLE
fix: fixed offset calculation for pagination

### DIFF
--- a/pagerduty/table_pagerduty_escalation_policy.go
+++ b/pagerduty/table_pagerduty_escalation_policy.go
@@ -159,7 +159,7 @@ func listPagerDutyEscalationPolicies(ctx context.Context, d *plugin.QueryData, h
 		if !listResponse.APIListObject.More {
 			break
 		}
-		req.APIListObject.Offset = listResponse.Offset + 1
+		req.APIListObject.Offset = listResponse.APIListObject.Offset + listResponse.APIListObject.Limit
 	}
 
 	return nil, nil

--- a/pagerduty/table_pagerduty_incident.go
+++ b/pagerduty/table_pagerduty_incident.go
@@ -217,10 +217,10 @@ func listPagerDutyIncidents(ctx context.Context, d *plugin.QueryData, h *plugin.
 			beforeTime := givenTime.Add(time.Duration(-1) * time.Second)
 			afterTime := givenTime.Add(time.Second * 1)
 
-		  // API doesn't supports listing incidents beyond 6 months
+			// API doesn't supports listing incidents beyond 6 months
 			// if the queried range is more than 6 months, set `date_range` attribute to 'all'
 			currentTime := time.Now().UTC()
-			diffInDays := (currentTime.Sub(givenTime).Hours())/24
+			diffInDays := (currentTime.Sub(givenTime).Hours()) / 24
 			if diffInDays > 180 {
 				req.DateRange = "all"
 				break
@@ -278,7 +278,8 @@ func listPagerDutyIncidents(ctx context.Context, d *plugin.QueryData, h *plugin.
 		if !listResponse.APIListObject.More {
 			break
 		}
-		req.APIListObject.Offset = listResponse.Offset + 1
+
+		req.APIListObject.Offset = listResponse.APIListObject.Offset + listResponse.APIListObject.Limit
 	}
 
 	return nil, nil

--- a/pagerduty/table_pagerduty_incident_log.go
+++ b/pagerduty/table_pagerduty_incident_log.go
@@ -193,7 +193,7 @@ func listPagerDutyIncidentLogs(ctx context.Context, d *plugin.QueryData, h *plug
 		if !listResponse.APIListObject.More {
 			break
 		}
-		req.APIListObject.Offset = listResponse.Offset + 1
+		req.APIListObject.Offset = listResponse.APIListObject.Offset + listResponse.APIListObject.Limit
 	}
 
 	return nil, nil

--- a/pagerduty/table_pagerduty_schedule.go
+++ b/pagerduty/table_pagerduty_schedule.go
@@ -172,7 +172,7 @@ func listPagerDutySchedules(ctx context.Context, d *plugin.QueryData, h *plugin.
 		if !listResponse.APIListObject.More {
 			break
 		}
-		req.APIListObject.Offset = listResponse.Offset + 1
+		req.APIListObject.Offset = listResponse.APIListObject.Offset + listResponse.APIListObject.Limit
 	}
 
 	return nil, nil

--- a/pagerduty/table_pagerduty_team.go
+++ b/pagerduty/table_pagerduty_team.go
@@ -146,7 +146,7 @@ func listPagerDutyTeams(ctx context.Context, d *plugin.QueryData, h *plugin.Hydr
 		if !listResponse.APIListObject.More {
 			break
 		}
-		req.APIListObject.Offset = listResponse.Offset + 1
+		req.APIListObject.Offset = listResponse.APIListObject.Offset + listResponse.APIListObject.Limit
 	}
 
 	return nil, nil

--- a/pagerduty/table_pagerduty_user.go
+++ b/pagerduty/table_pagerduty_user.go
@@ -206,7 +206,7 @@ func listPagerDutyUsers(ctx context.Context, d *plugin.QueryData, h *plugin.Hydr
 		if !listResponse.APIListObject.More {
 			break
 		}
-		req.APIListObject.Offset = listResponse.Offset + 1
+		req.APIListObject.Offset = listResponse.APIListObject.Offset + listResponse.APIListObject.Limit
 	}
 
 	return nil, nil

--- a/pagerduty/table_pagerduty_vendor.go
+++ b/pagerduty/table_pagerduty_vendor.go
@@ -182,7 +182,7 @@ func listPagerDutyVendors(ctx context.Context, d *plugin.QueryData, h *plugin.Hy
 		if !listResponse.APIListObject.More {
 			break
 		}
-		req.APIListObject.Offset = listResponse.Offset + 1
+		req.APIListObject.Offset = listResponse.APIListObject.Offset + listResponse.APIListObject.Limit
 	}
 
 	return nil, nil


### PR DESCRIPTION
While executing queries on our PagerDuty account I got unrealistic results (e.g. number of incidents per Service), during further investigation I found a major bug in the offset calculation which not only resulted in the the same incidents appearing multiple times in the response, but also the very slow query runtimes mentioned in #18.

# Query to check for duplicate incidents
```sql
select
    incident_number,
    count(*)
from
    pagerduty_incident
group by
    incident_number
HAVING
    count(*) > 1
```
  
```
+-----------------+-------+
| incident_number | count |
+-----------------+-------+
+-----------------+-------+
```

