### PR TITLE
Fix `title` column reference in `pagerduty_incident` and `pagerduty_incident_log` table. Closes #22

### DIFF
--- a/pagerduty/table_pagerduty_incident.go
+++ b/pagerduty/table_pagerduty_incident.go
@@ -181,7 +181,7 @@ func tablePagerDutyIncident(_ context.Context) *plugin.Table {
 				Name:        "title",
 				Description: "Title of the resource.",
 				Type:        proto.ColumnType_STRING,
-				Transform:   transform.FromField("summary"),
+				Transform:   transform.FromField("Summary"),
 			},
 		},
 	}

--- a/pagerduty/table_pagerduty_incident_log.go
+++ b/pagerduty/table_pagerduty_incident_log.go
@@ -106,7 +106,7 @@ func tablePagerDutyIncidentLog(_ context.Context) *plugin.Table {
 				Name:        "title",
 				Description: "Title of the resource.",
 				Type:        proto.ColumnType_STRING,
-				Transform:   transform.FromField("id"),
+				Transform:   transform.FromField("ID"),
 			},
 		},
 	}


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
Add example SQL query results here (please include the input queries as well)
```
</details>
